### PR TITLE
Allow use of overrideDatasources db url with Pool connectionString

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export const withPgAdapter = <PrismaClientType>(
     },
   })
 
-  const { url } = prisma._engineConfig.inlineDatasources.db
+  const { url } = prisma._engineConfig.overrideDatasources?.db ?? prisma._engineConfig.inlineDatasources.db
   const pool = new Pool({ connectionString: url.value || process.env[url.fromEnvVar] });
   const pgAdapter = new PrismaPg(pool, undefined, { logQueries });
   prisma._engineConfig.logQueries = false


### PR DESCRIPTION
When specifying the db url in the prisma client instantiation, the value is not currently honored as `withPgAdapter` only uses inlineDatasources or the ENV variables. This allows  for the following to work as expected.

```
withPgAdapter(new PrismaClient({
  datasources: {
    db: { url: DATABASE_URL }
}))
```